### PR TITLE
Update build to fix broken packaging of wibl modules

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/CCOMJHC/WIBL/archive/refs/tags/{{ name }}-{{ version }}.tar.gz
-  sha256: 1368b0ad592c8b203466169b1711d338b30186e3cb8fc5f081c19b6688fc9ec4
+  sha256: 124373ba5e35bf18b5b8d074c771808befe7fc6a213bad695c6f26bcca44f4e8
 
 build:
   entry_points:
@@ -17,7 +17,7 @@ build:
   script: |
     {{ PYTHON }} -m pip install ./wibl-python/wibl-manager
     {{ PYTHON }} -m pip install ./wibl-python -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -45,6 +45,7 @@ test:
     - pip
   commands:
     - pip check
+    - wibl --help
 
 about:
   home: https://github.com/CCOMJHC/WIBL/tree/wibl-python-1.0.3/wibl-python


### PR DESCRIPTION
Update build to use new pyproject.toml that does not explicitly list wibl and submodules.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
